### PR TITLE
Fix path to React build

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -54,6 +54,6 @@ app.use(invitationsRouter);
 // The "catchall" handler: for any request that doesn't
 // match one above, send back React's index.html file.
 app.get('/*', (req, res) => {
-  res.sendFile(path.join(__dirname + '../client/index.html'));
+  res.sendFile(path.join(__dirname, '../../client/build', 'index.html'));
 });
 app.listen(port, () => console.log(`app is running in PORT: ${port}`));


### PR DESCRIPTION
## Summary
- fix path to React build in server catch-all route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684109e0cb448326b2b7d7ed33ad353a